### PR TITLE
feat(wallet): adiciona endpoints de carteira e recarga simulada

### DIFF
--- a/mescla-backend/functions/src/wallet/handlers/depositToUserWallet.ts
+++ b/mescla-backend/functions/src/wallet/handlers/depositToUserWallet.ts
@@ -1,0 +1,46 @@
+// Autor: Gabriel Padreca Nicoletti
+// RA: 20013009
+
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+
+import { requireAuthenticatedUser } from "../../shared/auth";
+import { incrementUserBalanceCents } from "../repositories/walletRepository";
+
+// Recarga simulada de saldo. O documento de visão (seção 5.3) deixa claro que a carteira
+// é fictícia, então o usuário pode adicionar qualquer valor pra testar o trading depois.
+// Em sistema real isso seria integrado a gateway de pagamento (Pix, cartão, etc).
+export const depositToUserWallet = onCall(async (request) => {
+  try {
+    const user = requireAuthenticatedUser(request);
+    const { amountCents } = request.data;
+
+    if (
+      typeof amountCents !== "number" ||
+      !Number.isInteger(amountCents) ||
+      amountCents <= 0
+    ) {
+      throw new HttpsError(
+        "invalid-argument",
+        "Campo amountCents deve ser um inteiro positivo (em centavos)."
+      );
+    }
+
+    const newBalanceCents = await incrementUserBalanceCents(
+      user.uid,
+      amountCents
+    );
+
+    return {
+      data: {
+        balanceCents: newBalanceCents,
+      },
+    };
+  } catch (error) {
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+
+    console.error("Erro ao depositar saldo:", error);
+    throw new HttpsError("internal", "Erro ao depositar saldo.");
+  }
+});

--- a/mescla-backend/functions/src/wallet/handlers/getUserWallet.ts
+++ b/mescla-backend/functions/src/wallet/handlers/getUserWallet.ts
@@ -1,0 +1,44 @@
+// Autor: Gabriel Padreca Nicoletti
+// RA: 20013009
+
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+
+import { requireAuthenticatedUser } from "../../shared/auth";
+import { fetchUserAssets } from "../repositories/assetsRepository";
+import { getUserBalanceCents } from "../repositories/walletRepository";
+import { UserAssetView } from "../types/assetsTypes";
+
+export const getUserWallet = onCall(async (request) => {
+  try {
+    const user = requireAuthenticatedUser(request);
+
+    const [balanceCents, assets] = await Promise.all([
+      getUserBalanceCents(user.uid),
+      fetchUserAssets(user.uid),
+    ]);
+
+    const assetsView: UserAssetView[] = assets.map((asset) => ({
+      startupId: asset.startupId,
+      startupName: asset.startupName,
+      coverImageUrl: asset.coverImageUrl,
+      quantity: asset.quantity,
+      averagePriceCents: asset.averagePriceCents,
+      lastUpdatedAt: asset.lastUpdatedAt?.toDate?.()?.toISOString?.() ?? null,
+    }));
+
+    return {
+      data: {
+        balanceCents,
+        assets: assetsView,
+        assetsCount: assetsView.length,
+      },
+    };
+  } catch (error) {
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+
+    console.error("Erro ao buscar carteira do usuário:", error);
+    throw new HttpsError("internal", "Erro ao buscar carteira do usuário.");
+  }
+});

--- a/mescla-backend/functions/src/wallet/index.ts
+++ b/mescla-backend/functions/src/wallet/index.ts
@@ -1,2 +1,4 @@
 export { listUserAssets } from "./handlers/listUserAssets";
 export { getUserAssetByStartup } from "./handlers/getUserAssetByStartup";
+export { getUserWallet } from "./handlers/getUserWallet";
+export { depositToUserWallet } from "./handlers/depositToUserWallet";

--- a/mescla-backend/functions/src/wallet/repositories/walletRepository.ts
+++ b/mescla-backend/functions/src/wallet/repositories/walletRepository.ts
@@ -1,0 +1,27 @@
+// Autor: Gabriel Padreca Nicoletti
+// RA: 20013009
+
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
+
+import {
+  getUserByUid,
+  usersCollection,
+} from "../../users/repositories/usersRepository";
+
+export async function getUserBalanceCents(uid: string): Promise<number> {
+  const user = await getUserByUid(uid);
+  return user.balanceCents ?? 0;
+}
+
+export async function incrementUserBalanceCents(
+  uid: string,
+  amountCents: number
+): Promise<number> {
+  await usersCollection.doc(uid).update({
+    balanceCents: FieldValue.increment(amountCents),
+    updatedAt: Timestamp.now(),
+  });
+
+  const updated = await getUserByUid(uid);
+  return updated.balanceCents;
+}


### PR DESCRIPTION
endpoint que devolve saldo e ativos da carteira numa chamada só, e o de recarga simulada que adiciona valor fictício pra testar o trading depois.

a consulta da carteira faz os dois fetches em paralelo.