### PR TITLE
feat: add simulated token purchase flow

### DIFF
--- a/mescla-backend/functions/src/wallet/handlers/buyTokens.ts
+++ b/mescla-backend/functions/src/wallet/handlers/buyTokens.ts
@@ -1,0 +1,212 @@
+// Autor: Gabriel Padreca Nicoletti
+// RA: 20013009
+
+import {FieldValue, Timestamp} from "firebase-admin/firestore";
+import {HttpsError, onCall} from "firebase-functions/v2/https";
+
+import {requireAuthenticatedUser} from "../../shared/auth";
+import {db} from "../../shared/firebase";
+import {
+  startupsCollection,
+} from "../../startups/repositories/startupsRepository";
+import {StartupDocument} from "../../startups/types/startupTypes";
+import {usersCollection} from "../../users/repositories/usersRepository";
+import {UserDocument} from "../../users/types/usersTypes";
+import {
+  buildUserAsset,
+  calculateAveragePriceCents,
+  deleteUserAssetInTransaction,
+  fetchUserAssetInTransaction,
+  saveUserAssetInTransaction,
+} from "../repositories/assetsRepository";
+import {
+  saveTokenTransactionInTransaction,
+  toTokenTransactionView,
+} from "../repositories/transactionsRepository";
+import {
+  calculateTradeTotalCents,
+  requireStartupId,
+  requireTokenPrice,
+  requireTokenQuantity,
+  TRADING_COUNTERPARTY_UID,
+} from "../shared/tradingValidation";
+import {UserAssetDocument} from "../types/assetsTypes";
+import {TokenTransactionDocument} from "../types/transactionTypes";
+
+export const buyTokens = onCall(async (request) => {
+  try {
+    const user = requireAuthenticatedUser(request);
+    const startupId = requireStartupId(request.data?.startupId);
+    const quantity = requireTokenQuantity(request.data?.quantity);
+
+    if (user.uid === TRADING_COUNTERPARTY_UID) {
+      throw new HttpsError(
+        "failed-precondition",
+        "Usuário de liquidez não pode negociar pelo aplicativo.",
+      );
+    }
+
+    const result = await db.runTransaction(async (transaction) => {
+      const startupReference = startupsCollection.doc(startupId);
+      const buyerReference = usersCollection.doc(user.uid);
+      const sellerReference = usersCollection.doc(TRADING_COUNTERPARTY_UID);
+
+      const [startupSnapshot, buyerSnapshot, sellerSnapshot] =
+        await Promise.all([
+          transaction.get(startupReference),
+          transaction.get(buyerReference),
+          transaction.get(sellerReference),
+        ]);
+
+      if (!startupSnapshot.exists) {
+        throw new HttpsError("not-found", "Startup não encontrada.");
+      }
+
+      if (!buyerSnapshot.exists) {
+        throw new HttpsError(
+          "not-found",
+          "Usuário comprador não encontrado.",
+        );
+      }
+
+      if (!sellerSnapshot.exists) {
+        throw new HttpsError(
+          "failed-precondition",
+          "Usuário de liquidez não configurado.",
+        );
+      }
+
+      const startup = startupSnapshot.data() as StartupDocument;
+      const buyer = buyerSnapshot.data() as UserDocument;
+      const priceCents = requireTokenPrice(startup.currentTokenPriceCents);
+      const totalCents = calculateTradeTotalCents(quantity, priceCents);
+      const buyerBalanceCents = buyer.balanceCents ?? 0;
+
+      if (buyerBalanceCents < totalCents) {
+        throw new HttpsError(
+          "failed-precondition",
+          "Saldo insuficiente para comprar tokens.",
+        );
+      }
+
+      const [buyerAsset, sellerAsset] = await Promise.all([
+        fetchUserAssetInTransaction(transaction, user.uid, startupId),
+        fetchUserAssetInTransaction(
+          transaction,
+          TRADING_COUNTERPARTY_UID,
+          startupId,
+        ),
+      ]);
+
+      if (!sellerAsset || sellerAsset.quantity < quantity) {
+        throw new HttpsError(
+          "failed-precondition",
+          "Tokens insuficientes disponíveis no balcão.",
+        );
+      }
+
+      const now = Timestamp.now();
+      const currentBuyerQuantity = buyerAsset?.quantity ?? 0;
+      const currentBuyerAverage = buyerAsset?.averagePriceCents ?? priceCents;
+      const nextBuyerQuantity = currentBuyerQuantity + quantity;
+      const buyerAveragePriceCents = calculateAveragePriceCents({
+        currentQuantity: currentBuyerQuantity,
+        currentAveragePriceCents: currentBuyerAverage,
+        addedQuantity: quantity,
+        addedPriceCents: priceCents,
+      });
+      const buyerAssetData = buildUserAsset({
+        startupId,
+        startupName: startup.name,
+        coverImageUrl: startup.coverImageUrl,
+        quantity: nextBuyerQuantity,
+        averagePriceCents: buyerAveragePriceCents,
+        now,
+      });
+      const sellerRemainingQuantity = sellerAsset.quantity - quantity;
+
+      transaction.update(buyerReference, {
+        balanceCents: FieldValue.increment(-totalCents),
+        updatedAt: now,
+      });
+      transaction.update(sellerReference, {
+        balanceCents: FieldValue.increment(totalCents),
+        updatedAt: now,
+      });
+
+      saveUserAssetInTransaction(transaction, user.uid, buyerAssetData);
+
+      if (sellerRemainingQuantity === 0) {
+        deleteUserAssetInTransaction(
+          transaction,
+          TRADING_COUNTERPARTY_UID,
+          startupId,
+        );
+      } else {
+        const sellerAssetData: UserAssetDocument = {
+          ...sellerAsset,
+          startupName: startup.name,
+          coverImageUrl: startup.coverImageUrl,
+          quantity: sellerRemainingQuantity,
+          lastUpdatedAt: now,
+        };
+
+        saveUserAssetInTransaction(
+          transaction,
+          TRADING_COUNTERPARTY_UID,
+          sellerAssetData,
+        );
+      }
+
+      transaction.set(
+        startupReference.collection("investors").doc(user.uid),
+        {
+          uid: user.uid,
+          email: user.email ?? null,
+          startupId,
+          startupName: startup.name,
+          quantity: nextBuyerQuantity,
+          updatedAt: now,
+        },
+        {merge: true},
+      );
+
+      const tokenTransaction: TokenTransactionDocument = {
+        type: "buy",
+        startupId,
+        startupName: startup.name,
+        buyerUid: user.uid,
+        sellerUid: TRADING_COUNTERPARTY_UID,
+        actorUid: user.uid,
+        quantity,
+        priceCents,
+        totalCents,
+        createdAt: now,
+      };
+      const transactionId = saveTokenTransactionInTransaction(
+        transaction,
+        user.uid,
+        startupId,
+        tokenTransaction,
+      );
+
+      return {
+        balanceCents: buyerBalanceCents - totalCents,
+        asset: {
+          ...buyerAssetData,
+          lastUpdatedAt: buyerAssetData.lastUpdatedAt.toDate().toISOString(),
+        },
+        transaction: toTokenTransactionView(transactionId, tokenTransaction),
+      };
+    });
+
+    return {data: result};
+  } catch (error) {
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+
+    console.error("Erro ao comprar tokens:", error);
+    throw new HttpsError("internal", "Erro ao comprar tokens.");
+  }
+});

--- a/mescla-backend/functions/src/wallet/handlers/listUserTransactions.ts
+++ b/mescla-backend/functions/src/wallet/handlers/listUserTransactions.ts
@@ -1,0 +1,28 @@
+// Autor: Gabriel Padreca Nicoletti
+// RA: 20013009
+
+import {HttpsError, onCall} from "firebase-functions/v2/https";
+
+import {requireAuthenticatedUser} from "../../shared/auth";
+import {
+  fetchUserTokenTransactions,
+} from "../repositories/transactionsRepository";
+
+export const listUserTransactions = onCall(async (request) => {
+  try {
+    const user = requireAuthenticatedUser(request);
+    const transactions = await fetchUserTokenTransactions(user.uid);
+
+    return {
+      count: transactions.length,
+      data: transactions,
+    };
+  } catch (error) {
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+
+    console.error("Erro ao listar transações do usuário:", error);
+    throw new HttpsError("internal", "Erro ao listar transações do usuário.");
+  }
+});

--- a/mescla-backend/functions/src/wallet/index.ts
+++ b/mescla-backend/functions/src/wallet/index.ts
@@ -1,4 +1,6 @@
-export { listUserAssets } from "./handlers/listUserAssets";
-export { getUserAssetByStartup } from "./handlers/getUserAssetByStartup";
-export { getUserWallet } from "./handlers/getUserWallet";
-export { depositToUserWallet } from "./handlers/depositToUserWallet";
+export {listUserAssets} from "./handlers/listUserAssets";
+export {getUserAssetByStartup} from "./handlers/getUserAssetByStartup";
+export {getUserWallet} from "./handlers/getUserWallet";
+export {depositToUserWallet} from "./handlers/depositToUserWallet";
+export {buyTokens} from "./handlers/buyTokens";
+export {listUserTransactions} from "./handlers/listUserTransactions";

--- a/mescla-backend/functions/src/wallet/repositories/assetsRepository.ts
+++ b/mescla-backend/functions/src/wallet/repositories/assetsRepository.ts
@@ -1,22 +1,30 @@
 // Autor: Gabriel Padreca Nicoletti
 // RA: 20013009
 
-import { usersCollection } from "../../users/repositories/usersRepository";
-import { UserAssetDocument } from "../types/assetsTypes";
+import {Timestamp, Transaction} from "firebase-admin/firestore";
 
-function userAssetsCollection(uid: string) {
+import {usersCollection} from "../../users/repositories/usersRepository";
+import {UserAssetDocument} from "../types/assetsTypes";
+
+const userAssetsCollection = (uid: string) => {
   return usersCollection.doc(uid).collection("assets");
-}
+};
 
-export async function fetchUserAssets(uid: string): Promise<UserAssetDocument[]> {
+export const userAssetReference = (uid: string, startupId: string) => {
+  return userAssetsCollection(uid).doc(startupId);
+};
+
+export const fetchUserAssets = async (
+  uid: string,
+): Promise<UserAssetDocument[]> => {
   const snapshot = await userAssetsCollection(uid).get();
   return snapshot.docs.map((doc) => doc.data() as UserAssetDocument);
-}
+};
 
-export async function fetchUserAsset(
+export const fetchUserAsset = async (
   uid: string,
-  startupId: string
-): Promise<UserAssetDocument | undefined> {
+  startupId: string,
+): Promise<UserAssetDocument | undefined> => {
   const snapshot = await userAssetsCollection(uid).doc(startupId).get();
 
   if (!snapshot.exists) {
@@ -24,4 +32,75 @@ export async function fetchUserAsset(
   }
 
   return snapshot.data() as UserAssetDocument;
-}
+};
+
+export const fetchUserAssetInTransaction = async (
+  transaction: Transaction,
+  uid: string,
+  startupId: string,
+): Promise<UserAssetDocument | undefined> => {
+  const snapshot = await transaction.get(userAssetReference(uid, startupId));
+
+  if (!snapshot.exists) {
+    return undefined;
+  }
+
+  return snapshot.data() as UserAssetDocument;
+};
+
+export const saveUserAssetInTransaction = (
+  transaction: Transaction,
+  uid: string,
+  asset: UserAssetDocument,
+): void => {
+  transaction.set(
+    userAssetReference(uid, asset.startupId),
+    asset,
+    {merge: true},
+  );
+};
+
+export const deleteUserAssetInTransaction = (
+  transaction: Transaction,
+  uid: string,
+  startupId: string,
+): void => {
+  transaction.delete(userAssetReference(uid, startupId));
+};
+
+export const buildUserAsset = (params: {
+  startupId: string;
+  startupName: string;
+  coverImageUrl?: string;
+  quantity: number;
+  averagePriceCents: number;
+  now: Timestamp;
+}): UserAssetDocument => {
+  return {
+    startupId: params.startupId,
+    startupName: params.startupName,
+    coverImageUrl: params.coverImageUrl,
+    quantity: params.quantity,
+    averagePriceCents: params.averagePriceCents,
+    lastUpdatedAt: params.now,
+  };
+};
+
+export const calculateAveragePriceCents = (params: {
+  currentQuantity: number;
+  currentAveragePriceCents: number;
+  addedQuantity: number;
+  addedPriceCents: number;
+}): number => {
+  const nextQuantity = params.currentQuantity + params.addedQuantity;
+
+  if (nextQuantity <= 0) {
+    return 0;
+  }
+
+  const currentTotal =
+    params.currentQuantity * params.currentAveragePriceCents;
+  const addedTotal = params.addedQuantity * params.addedPriceCents;
+
+  return Math.round((currentTotal + addedTotal) / nextQuantity);
+};

--- a/mescla-backend/functions/src/wallet/repositories/transactionsRepository.ts
+++ b/mescla-backend/functions/src/wallet/repositories/transactionsRepository.ts
@@ -1,0 +1,86 @@
+// Autor: Gabriel Padreca Nicoletti
+// RA: 20013009
+
+import {Transaction} from "firebase-admin/firestore";
+
+import {db} from "../../shared/firebase";
+import {
+  startupsCollection,
+} from "../../startups/repositories/startupsRepository";
+import {usersCollection} from "../../users/repositories/usersRepository";
+import {
+  TokenTransactionDocument,
+  TokenTransactionView,
+} from "../types/transactionTypes";
+
+export const transactionsCollection = db.collection("transactions");
+
+export const createTokenTransactionReferences = (
+  uid: string,
+  startupId: string,
+) => {
+  const transactionReference = transactionsCollection.doc();
+
+  return {
+    id: transactionReference.id,
+    globalReference: transactionReference,
+    userReference: usersCollection
+      .doc(uid)
+      .collection("transactions")
+      .doc(transactionReference.id),
+    startupReference: startupsCollection
+      .doc(startupId)
+      .collection("transactions")
+      .doc(transactionReference.id),
+  };
+};
+
+export const saveTokenTransactionInTransaction = (
+  transaction: Transaction,
+  uid: string,
+  startupId: string,
+  document: TokenTransactionDocument,
+): string => {
+  const references = createTokenTransactionReferences(uid, startupId);
+
+  transaction.set(references.globalReference, document);
+  transaction.set(references.userReference, document);
+  transaction.set(references.startupReference, document);
+
+  return references.id;
+};
+
+export const fetchUserTokenTransactions = async (
+  uid: string,
+  limit = 50,
+): Promise<TokenTransactionView[]> => {
+  const snapshot = await usersCollection
+    .doc(uid)
+    .collection("transactions")
+    .orderBy("createdAt", "desc")
+    .limit(limit)
+    .get();
+
+  return snapshot.docs.map((doc) =>
+    toTokenTransactionView(doc.id, doc.data() as TokenTransactionDocument),
+  );
+};
+
+export const toTokenTransactionView = (
+  id: string,
+  transaction: TokenTransactionDocument,
+): TokenTransactionView => {
+  return {
+    id,
+    type: transaction.type,
+    startupId: transaction.startupId,
+    startupName: transaction.startupName,
+    buyerUid: transaction.buyerUid,
+    sellerUid: transaction.sellerUid,
+    actorUid: transaction.actorUid,
+    quantity: transaction.quantity,
+    priceCents: transaction.priceCents,
+    totalCents: transaction.totalCents,
+    createdAt: transaction.createdAt?.toDate?.()?.toISOString?.() ?? null,
+  };
+};

--- a/mescla-backend/functions/src/wallet/shared/tradingValidation.ts
+++ b/mescla-backend/functions/src/wallet/shared/tradingValidation.ts
@@ -1,0 +1,63 @@
+// Autor: Gabriel Padreca Nicoletti
+// RA: 20013009
+
+import {HttpsError} from "firebase-functions/v2/https";
+
+export const TRADING_COUNTERPARTY_UID =
+  process.env.TRADING_COUNTERPARTY_UID ?? "mescla-market-maker";
+
+export const requireStartupId = (value: unknown): string => {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new HttpsError("invalid-argument", "Campo startupId é obrigatório.");
+  }
+
+  return value.trim();
+};
+
+export const requireTokenQuantity = (value: unknown): number => {
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    !Number.isSafeInteger(value) ||
+    value <= 0
+  ) {
+    throw new HttpsError(
+      "invalid-argument",
+      "Campo quantity deve ser um inteiro positivo.",
+    );
+  }
+
+  return value;
+};
+
+export const requireTokenPrice = (priceCents: unknown): number => {
+  if (
+    typeof priceCents !== "number" ||
+    !Number.isInteger(priceCents) ||
+    !Number.isSafeInteger(priceCents) ||
+    priceCents <= 0
+  ) {
+    throw new HttpsError(
+      "failed-precondition",
+      "Startup sem preço válido para negociação.",
+    );
+  }
+
+  return priceCents;
+};
+
+export const calculateTradeTotalCents = (
+  quantity: number,
+  priceCents: number,
+): number => {
+  const totalCents = quantity * priceCents;
+
+  if (!Number.isSafeInteger(totalCents)) {
+    throw new HttpsError(
+      "invalid-argument",
+      "Valor total da negociação é muito alto.",
+    );
+  }
+
+  return totalCents;
+};

--- a/mescla-backend/functions/src/wallet/types/transactionTypes.ts
+++ b/mescla-backend/functions/src/wallet/types/transactionTypes.ts
@@ -1,0 +1,33 @@
+// Autor: Gabriel Padreca Nicoletti
+// RA: 20013009
+
+import {Timestamp} from "firebase-admin/firestore";
+
+export type TokenTransactionType = "buy" | "sell";
+
+export type TokenTransactionDocument = {
+  type: TokenTransactionType;
+  startupId: string;
+  startupName: string;
+  buyerUid: string;
+  sellerUid: string;
+  actorUid: string;
+  quantity: number;
+  priceCents: number;
+  totalCents: number;
+  createdAt: Timestamp;
+};
+
+export type TokenTransactionView = {
+  id: string;
+  type: TokenTransactionType;
+  startupId: string;
+  startupName: string;
+  buyerUid: string;
+  sellerUid: string;
+  actorUid: string;
+  quantity: number;
+  priceCents: number;
+  totalCents: number;
+  createdAt: string | null;
+};


### PR DESCRIPTION
compra simulada de tokens no backend, validando usuário autenticado, saldo disponível e quantidade de tokens antes de concluir a operação.

deixei a compra salvando histórico, atualizando saldo/carteira e marcando o usuário como investidor da startup, garantindo que tudo aconteça junto ou nada seja salvo em caso de erro.